### PR TITLE
Add serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ maintenance = { status = "passively-maintained" }
 
 [dependencies]
 num-traits = "0.2"
+serde = { version = "1.0", features = ["derive"], optional = true }
+
+[features]
+serde = ["dep:serde"]
 
 [package.metadata.release]
 pre-release-replacements = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ use std::{cmp, fmt};
 
 /// A polynomial.
 #[derive(Eq, PartialEq, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Polynomial<T> {
     data: Vec<T>,
 }


### PR DESCRIPTION
This change adds serde support to the crate.  It updates cargo to include serde as an optional feature, so users who don't need serde will by default not get it.  It also adds ```#derive``` directives if the serde feature is enabled.
