### PR TITLE
Add support for no_std environments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ description = "A library for manipulating polynomials"
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-num-traits = "0.2"
+num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [features]
 serde = ["dep:serde"]
 default = ["std"]
-std = []
+std = ["num-traits/std"]
 
 [package.metadata.release]
 pre-release-replacements = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 
 [features]
 serde = ["dep:serde"]
+default = ["std"]
+std = []
 
 [package.metadata.release]
 pre-release-replacements = [

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ Add this to your `Cargo.toml`:
 polynomial = "0.2.5"
 ```
 
+## no_std environments
+
+The library can be used in a no_std environment, so long as a global allocator is present. Simply add the `default-features = false` attribute to `Cargo.toml`:
+```toml
+[dependencies]
+polynomial = {version = "0.2.5", default-features = false}
+```
+
 ## Minimum supported Rust version (MSRV)
 
 The minimum supported Rust version is **Rust 1.70.0**.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,9 @@ use alloc::{
     vec::Vec,
 };
 
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
+
 /// A polynomial.
 #[derive(Eq, PartialEq, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //! A library for manipulating polynomials.
-
+#![cfg_attr(not(feature = "std"), no_std)]
 #![warn(bad_style)]
 #![warn(missing_docs)]
 #![warn(trivial_casts)]
@@ -10,9 +10,20 @@
 #![warn(unused_qualifications)]
 #![warn(unused_results)]
 
+use core::ops::{Add, Div, Mul, Neg, Sub};
+use core::{cmp, fmt};
 use num_traits::{FromPrimitive, One, Zero};
-use std::ops::{Add, Div, Mul, Neg, Sub};
-use std::{cmp, fmt};
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::{
+    format,
+    string::{String, ToString},
+    vec,
+    vec::Vec,
+};
 
 /// A polynomial.
 #[derive(Eq, PartialEq, Clone, Debug)]
@@ -118,7 +129,7 @@ where
 
         let mut xs = Vec::new();
         for i in 0..n {
-            use std::f64::consts::PI;
+            use core::f64::consts::PI;
             let x = T::from_f64(
                 (xmax + xmin) * 0.5
                     + (xmin - xmax) * 0.5 * ((2 * i + 1) as f64 * PI / (2 * n) as f64).cos(),
@@ -414,6 +425,12 @@ impl<T: Zero + One + Clone> One for Polynomial<T> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(feature = "std"))]
+    extern crate alloc;
+
+    #[cfg(not(feature = "std"))]
+    use alloc::{string::ToString, vec, vec::Vec};
+
     use super::Polynomial;
 
     #[test]
@@ -545,7 +562,7 @@ mod tests {
         }
 
         // Approximate some common functions.
-        use std::f64::consts::PI;
+        use core::f64::consts::PI;
         check(&f64::sin, 7, -PI / 2., PI / 2.);
         check(&f64::cos, 7, 0., PI / 4.);
 


### PR DESCRIPTION
Hi,
This change allows the library to be used in no_std environments, such as microcontrollers - so long as a global allocator is present.
no_std mode can be enabled by simply adding the `default-features = false` attribute to Cargo.toml:
```
[dependencies]
polynomial = {version = "0.2.5", default-features = false}
```