### PR TITLE
Add CI test coverage to benchmark suite

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -118,3 +118,20 @@ jobs:
           files: lcov.info
           fail_ci_if_error: true
 
+  benchmark_check:
+    name: Benchmark Check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        feature_flags:
+          - "--workspace --all-features"
+          - "--workspace --no-default-features"
+          - "-p polynomial --no-default-features --features=std"
+          - "-p polynomial --no-default-features --features=libm"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+      - name: Compile benchmarks (without running)
+        run: cargo bench --no-run ${{ matrix.feature_flags }}

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -121,17 +121,10 @@ jobs:
   benchmark_check:
     name: Benchmark Check
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        feature_flags:
-          - "--workspace --all-features"
-          - "--workspace --no-default-features"
-          - "-p polynomial --no-default-features --features=std"
-          - "-p polynomial --no-default-features --features=libm"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
       - name: Compile benchmarks (without running)
-        run: cargo bench --no-run ${{ matrix.feature_flags }}
+        run: cargo bench --no-run


### PR DESCRIPTION
Tells the GitHub actions to compile the benchmarks:
```
cargo bench --no-run
```
As part of the CI testing.